### PR TITLE
setup.py: Fix build error in non-utf8 environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from distutils.core import setup
 
 version = '1.0.0'
-with open('README.rst') as f:
+with open('README.rst', encoding = "utf-8") as f:
     long_description = f.read()
 
 setup(name='ofxstatement-seb',


### PR DESCRIPTION
setup.py fails if you call it in non-utf8 environment:

```
$ LANG=C python3 setup.py clean
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    long_description = f.read()
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 639: ordinal not in range(128)
```

This commit fixes the error.